### PR TITLE
[Funkce] [Web] Přihlašování uživatelů přes JWT

### DIFF
--- a/src/api/app/Controller/Admin/AuthController.php
+++ b/src/api/app/Controller/Admin/AuthController.php
@@ -6,16 +6,43 @@ namespace JR\Tracker\Controller\Admin;
 
 use JR\Tracker\Enum\HttpStatusCode;
 use JR\Tracker\Enum\DomainContextEnum;
+use JR\Tracker\Shared\Helper\BooleanHelper;
+use JR\Tracker\DataObject\Data\LoginUserData;
 use Psr\Http\Message\ResponseInterface as Response;
 use JR\Tracker\Service\Contract\AuthServiceInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use JR\Tracker\Shared\ResponseFormatter\ResponseFormatter;
+use JR\Tracker\RequestValidator\Auth\UserLoginRequestValidator;
+use JR\Tracker\RequestValidator\Request\Contract\RequestValidatorFactoryInterface;
 
 
 class AuthController
 {
     public function __construct(
+        private readonly RequestValidatorFactoryInterface $requestValidatorFactory,
         private readonly AuthServiceInterface $authService,
+        private readonly ResponseFormatter $responseFormatter
     ) {
+    }
+
+    public function login(Request $request, Response $response): Response
+    {
+        $data = $this->requestValidatorFactory->make(UserLoginRequestValidator::class)->validate(
+            $request->getParsedBody()
+        );
+
+        $parseBoolean = BooleanHelper::parse();
+
+        $loginResult = $this->authService->attemptLogin(
+            new LoginUserData(
+                $data['email'],
+                $data['password'],
+                $parseBoolean(($data['persistLogin'] ?? false))
+            ),
+            DomainContextEnum::ADMIN
+        );
+
+        return $this->responseFormatter->asJson($response, $loginResult);
     }
 
     public function logout(Request $request, Response $response): Response

--- a/src/api/app/Fixture/Fixtures/UserRolePermissionFixture.php
+++ b/src/api/app/Fixture/Fixtures/UserRolePermissionFixture.php
@@ -15,6 +15,35 @@ class UserRolePermissionFixture implements FixtureInterface
     public function load(ObjectManager $manager): void
     {
         $rolePermissionMap = [
+            'OWNER' => [
+                'USER_VIEW',
+                'USER_EDIT',
+                'USER_DELETE',
+                'ROLE_ASSIGN',
+                'PERMISSION_EDIT',
+
+                'CONSUMPTION_VIEW',
+                'CONSUMPTION_EDIT',
+                'CONSUMPTION_DELETE',
+
+                'METER_VIEW',
+                'METER_EDIT',
+                'METER_DELETE',
+
+                'PRICE_VIEW',
+                'PRICE_EDIT',
+                'PRICE_DELETE',
+
+                'INVOICE_VIEW',
+                'INVOICE_EDIT',
+                'INVOICE_DELETE',
+
+                'TICKET_VIEW',
+                'TICKET_MANAGE',
+
+                'LOG_VIEW',
+                'SETTINGS_EDIT',
+            ],        
             // SUPER_ADMIN = vše, plná kontrola nad systémem
             'SUPER_ADMIN' => [
                 // uživatelé

--- a/src/api/app/Service/Contract/TokenServiceInterface.php
+++ b/src/api/app/Service/Contract/TokenServiceInterface.php
@@ -19,12 +19,12 @@ interface TokenServiceInterface
      * @return string
      * @author Jan Ribka
      */
-    public function createAccessToken(UserInterface $user, array $roles, ?TokenConfig $config = null): string;
+    public function createAccessToken(UserInterface $user, array $roles, TokenConfig $config): string;
 
-    public function createRefreshToken(UserInterface $user, ?TokenConfig $config = null): string;
+    public function createRefreshToken(UserInterface $user, TokenConfig $config): string;
 
-    public function verifyJWT(ServerRequestInterface $request, RequestHandlerInterface $handler, ?TokenConfig $config = null): ResponseInterface;
+    public function verifyJWT(ServerRequestInterface $request, RequestHandlerInterface $handler, TokenConfig $config): ResponseInterface;
 
-    public function decodeToken(string $token, string $tokenKey, ?string $algorithm = null): object|null;
+    public function decodeToken(string $token, string $tokenKey, string $algorithm): object|null;
 }
 

--- a/src/api/app/Service/Implementation/TokenService.php
+++ b/src/api/app/Service/Implementation/TokenService.php
@@ -20,14 +20,12 @@ class TokenService implements TokenServiceInterface
 {
     public function __construct(
         private readonly ResponseFactoryInterface $responseFactory,
-        private readonly TokenConfig $config // TODO: remove
     ) {
     }
 
 
-    public function createAccessToken(UserInterface $user, array $roles, ?TokenConfig $config = null): string
+    public function createAccessToken(UserInterface $user, array $roles, TokenConfig $config): string
     {
-        $config = $config ?? $this->config;
 
         $payload = [
             'userInfo' => [
@@ -45,9 +43,8 @@ class TokenService implements TokenServiceInterface
         );
     }
 
-    public function createRefreshToken(UserInterface $user, ?TokenConfig $config = null): string
+    public function createRefreshToken(UserInterface $user, TokenConfig $config): string
     {
-        $config = $config ?? $this->config;
 
         $payload = [
             'uuid' => $user->getUuid(),
@@ -62,9 +59,8 @@ class TokenService implements TokenServiceInterface
         );
     }
 
-    public function verifyJWT(ServerRequestInterface $request, RequestHandlerInterface $handler, ?TokenConfig $config = null): ResponseInterface
+    public function verifyJWT(ServerRequestInterface $request, RequestHandlerInterface $handler, TokenConfig $config): ResponseInterface
     {
-        $config = $config ?? $this->config;
         $authHeader = $request->getHeaderLine('HTTP_AUTHORIZATION');
 
         if (!$authHeader || !str_starts_with($authHeader, 'Bearer ')) {
@@ -92,10 +88,10 @@ class TokenService implements TokenServiceInterface
         }
     }
 
-    public function decodeToken(string $token, string $tokenKey, ?string $algorithm = null): object|null
+    public function decodeToken(string $token, string $tokenKey, string $algorithm): object|null
     {
         try {
-            $key = new Key($tokenKey, $algorithm ?? $this->config->algorithm);
+            $key = new Key($tokenKey, $algorithm);
 
             return JWT::decode($token, $key);
         } catch (Exception) {

--- a/src/api/app/Strategy/Contract/AuthStrategyInterface.php
+++ b/src/api/app/Strategy/Contract/AuthStrategyInterface.php
@@ -6,9 +6,11 @@ namespace JR\Tracker\Strategy\Contract;
 
 use JR\Tracker\DataObject\Config\TokenConfig;
 use JR\Tracker\DataObject\Config\AuthCookieConfig;
+use JR\Tracker\Entity\User\Contract\UserInterface;
 
 interface AuthStrategyInterface
 {
     public function getTokenConfig(): TokenConfig;
     public function getCookieConfig(?bool $persistLogin = false): AuthCookieConfig;
+    public function verifyUser(?UserInterface $user, string $password): void;
 }

--- a/src/api/app/Strategy/Implementation/AdminAuthStrategy.php
+++ b/src/api/app/Strategy/Implementation/AdminAuthStrategy.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace JR\Tracker\Strategy\Implementation;
 
+use JR\Tracker\Enum\HttpStatusCode;
+use JR\Tracker\Enum\UserRoleTypeEnum;
+use JR\Tracker\Enum\DomainContextEnum;
+use JR\Tracker\Shared\Helper\UserRoleHelper;
+use JR\Tracker\Exception\ValidationException;
 use JR\Tracker\DataObject\Config\TokenConfig;
 use JR\Tracker\DataObject\Config\AdminTokenConfig;
 use JR\Tracker\DataObject\Config\AuthCookieConfig;
 use JR\Tracker\DataObject\Config\AdminAuthCookieConfig;
+use JR\Tracker\Entity\User\Contract\UserInterface;
 use JR\Tracker\Strategy\Contract\AuthStrategyInterface;
+use JR\Tracker\Repository\Contract\UserRepositoryInterface;
 
 class AdminAuthStrategy implements AuthStrategyInterface
 {
     public function __construct(
         private readonly AdminTokenConfig $tokenConfig,
-        private readonly AdminAuthCookieConfig $authCookieConfig
+        private readonly AdminAuthCookieConfig $authCookieConfig,
+        private readonly UserRepositoryInterface $userRepository,
     ) {
     }
 
@@ -34,5 +42,39 @@ class AdminAuthStrategy implements AuthStrategyInterface
             $persistLogin ? $this->authCookieConfig->expires : 0,
             $this->authCookieConfig->path
         );
+    }
+
+    public function verifyUser(?UserInterface $user, string $password): void
+    {
+        if (!isset($user)) {
+            throw new ValidationException(['unauthorized' => ['incorrectLoginPassword']], HttpStatusCode::UNAUTHORIZED->value);
+        }
+
+        if ($user->getAdminLoginRestrictedUntil() && $user->getAdminLoginRestrictedUntil() > new \DateTime()) {
+            throw new ValidationException(['forbidden' => ['loginRestricted']], HttpStatusCode::FORBIDDEN->value);
+        }
+
+        if ($user->getIsDisabled()) {
+            throw new ValidationException(['forbidden' => ['accessDenied']], HttpStatusCode::FORBIDDEN->value);
+        }
+
+        if (!password_verify($password, $user->getPassword())) {
+            $this->userRepository->logLoginAttempt(DomainContextEnum::ADMIN, $user, false);
+
+            throw new ValidationException(['unauthorized' => ['incorrectLoginPassword']], HttpStatusCode::UNAUTHORIZED->value);
+        }
+
+        $emailVerifiedAt = $user->getEmailVerifiedAt();
+        if (!isset($emailVerifiedAt)) {
+            throw new ValidationException(['forbidden' => ['emailNotVerified']], HttpStatusCode::FORBIDDEN->value);
+        }
+
+        $userRoles = $this->userRepository->getRoleByIdUser($user->getUuid());
+
+        if (!UserRoleHelper::hasRole($userRoles, UserRoleTypeEnum::ADMIN)) {
+            $this->userRepository->logLoginAttempt(DomainContextEnum::ADMIN, $user, false);
+
+            throw new ValidationException(['forbidden' => ['accessDenied']], HttpStatusCode::FORBIDDEN->value);
+        }
     }
 }

--- a/src/api/app/Strategy/Implementation/WebAuthStrategy.php
+++ b/src/api/app/Strategy/Implementation/WebAuthStrategy.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace JR\Tracker\Strategy\Implementation;
 
+use JR\Tracker\Enum\HttpStatusCode;
+use JR\Tracker\Enum\UserRoleTypeEnum;
+use JR\Tracker\Enum\DomainContextEnum;
+use JR\Tracker\Shared\Helper\UserRoleHelper;
+use JR\Tracker\Exception\ValidationException;
 use JR\Tracker\DataObject\Config\TokenConfig;
 use JR\Tracker\DataObject\Config\AuthCookieConfig;
+use JR\Tracker\Entity\User\Contract\UserInterface;
 use JR\Tracker\Strategy\Contract\AuthStrategyInterface;
+use JR\Tracker\Repository\Contract\UserRepositoryInterface;
 
 class WebAuthStrategy implements AuthStrategyInterface
 {
     public function __construct(
         private readonly TokenConfig $tokenConfig,
-        private readonly AuthCookieConfig $authCookieConfig
+        private readonly AuthCookieConfig $authCookieConfig,
+        private readonly UserRepositoryInterface $userRepository,
     ) {
     }
 
@@ -31,5 +39,39 @@ class WebAuthStrategy implements AuthStrategyInterface
             $persistLogin ? $this->authCookieConfig->expires : 0, // 0 = session
             $this->authCookieConfig->path
         );
+    }
+
+    public function verifyUser(?UserInterface $user, string $password): void
+    {
+        if (!isset($user)) {
+            throw new ValidationException(['unauthorized' => ['incorrectLoginPassword']], HttpStatusCode::UNAUTHORIZED->value);
+        }
+
+        if ($user->getWebLoginRestrictedUntil() && $user->getWebLoginRestrictedUntil() > new \DateTime()) {
+            throw new ValidationException(['forbidden' => ['loginRestricted']], HttpStatusCode::FORBIDDEN->value);
+        }
+
+        if ($user->getIsDisabled()) {
+            throw new ValidationException(['forbidden' => ['accessDenied']], HttpStatusCode::FORBIDDEN->value);
+        }
+
+        if (!password_verify($password, $user->getPassword())) {
+            $this->userRepository->logLoginAttempt(DomainContextEnum::WEB, $user, false);
+
+            throw new ValidationException(['unauthorized' => ['incorrectLoginPassword']], HttpStatusCode::UNAUTHORIZED->value);
+        }
+
+        $emailVerifiedAt = $user->getEmailVerifiedAt();
+        if (!isset($emailVerifiedAt)) {
+            throw new ValidationException(['forbidden' => ['emailNotVerified']], HttpStatusCode::FORBIDDEN->value);
+        }
+
+        $userRoles = $this->userRepository->getRoleByIdUser($user->getUuid());
+
+        if (!UserRoleHelper::hasRole($userRoles, UserRoleTypeEnum::EDITOR)) {
+            $this->userRepository->logLoginAttempt(DomainContextEnum::WEB, $user, false);
+
+            throw new ValidationException(['forbidden' => ['accessDenied']], HttpStatusCode::FORBIDDEN->value);
+        }
     }
 }


### PR DESCRIPTION
<!-- Díky moc za tvůj pull request! ❤️ -->

### ✅ Co bylo změněno

Strategy Pattern pro Auth: Verifikace uživatele a konfigurace cookies/tokenů se nyní liší podle domény (Web vs. Administrace).
Refaktoring 
AuthService
: Odstraněna redundantní logika; ověřování rolí a omezení přihlášení delegováno na konkrétní strategie.
Implementace Admin login: Přidána plná podpora pro přihlášení administrátorů.
Upgrade TokenService: Metody nyní přijímají konfiguraci jako parametr pro lepší flexibilitu.
Fixtures: Přidána role OWNER s kompletními oprávněními.

### 🧪 Jak otestovat

Web login: Přihlášení přes webové rozhraní (vyžaduje roli EDITOR, cookie _refreshToken).
Admin login: Přihlášení do administrace (vyžaduje roli ADMIN, cookie admin_refreshToken).
Validace: Ověření, že špatné heslo nebo chybějící role správně logují neúspěšné pokusy v dané doméně.

### 📎 Další poznámky

Změna zajišťuje, že doménová pravidla (např. restrictedUntil) jsou od sebe izolovaná a nezávislá.

closes #5 

---

- [x] Dodržel(a) jsem pravidla uvedená v [příspěvkovém průvodci](CONTRIBUTING.md).
- [x] Změny jsou přehledné a dobře zdokumentované.
- [x] Pokud je potřeba, přidal(a) jsem testy nebo aktualizoval(a) dokumentaci.
