### PR TITLE
Add phpMyAdmin to host-services stack

### DIFF
--- a/docker/docker-compose.host-services.yml
+++ b/docker/docker-compose.host-services.yml
@@ -54,6 +54,22 @@ services:
       timeout: 5s
       retries: 5
 
+  phpmyadmin:
+    image: phpmyadmin:latest
+    container_name: consumption-tracker-phpmyadmin
+    restart: unless-stopped
+    ports:
+      # jen na loopbacku - nikdy vystaveno mimo server, pristup pres SSH tunel
+      - "127.0.0.1:8081:80"
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - host-services
+
 networks:
   host-services:
     driver: bridge


### PR DESCRIPTION
phpMyAdmin natrvalo v docker-compose.host-services.yml, ale jen na 127.0.0.1 - přístup přes SSH tunel.