### PR TITLE
Fix Doctrine ORM defaulting to 127.0.0.1 for its Redis cache

### DIFF
--- a/src/api/configs/container/container_bindings.php
+++ b/src/api/configs/container/container_bindings.php
@@ -111,10 +111,12 @@ return [
     #endregion
 
     #region Database
-  EntityManagerInterface::class => function (Config $config) {
+  EntityManagerInterface::class => function (Config $config, RedisAdapter $redisAdapter) {
     $ormConfig = ORMSetup::createAttributeMetadataConfiguration(
       $config->get('doctrine.entity_dir'),
       $config->get('doctrine.dev_mode'),
+      null,
+      $redisAdapter,
     );
 
     $ormConfig->enableNativeLazyObjects(true);


### PR DESCRIPTION
## Summary
- `ORMSetup::createAttributeMetadataConfiguration()` v produkčním režimu (`dev_mode: false`) samo vytváří Redis cache s výchozí adresou `127.0.0.1`, pokud mu žádnou nedáme - úplně nezávisle na `REDIS_HOST`
- Oprava: předat už existující, správně nakonfigurovanou `RedisAdapter` instanci jako 4. parametr
- Projeveno prvně teď, protože `APP_ENV=production` se v praxi ještě nikdy nespustilo (ani lokálně)

## Test plan
- [x] `php -l` bez chyby
- [x] `phpstan analyse app` čistý (stejný rozsah jako CI)
- [ ] Po nasazení ověřit, že appka v k8s dev prostředí odpovídá bez 500 chyby