### PR TITLE
Start session before CSRF Guard when CSRF is enabled

### DIFF
--- a/src/api/app/Middleware/SessionStartMiddleware.php
+++ b/src/api/app/Middleware/SessionStartMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JR\Tracker\Middleware;
+
+use JR\Tracker\Service\Contract\SessionServiceInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SessionStartMiddleware implements MiddlewareInterface
+{
+  public function __construct(
+    private readonly SessionServiceInterface $sessionService
+  ) {
+  }
+
+  public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+  {
+    if (!$this->sessionService->isActive()) {
+      $this->sessionService->start();
+    }
+
+    return $handler->handle($request);
+  }
+}

--- a/src/api/configs/middleware.php
+++ b/src/api/configs/middleware.php
@@ -6,6 +6,7 @@ use Clockwork\Clockwork;
 use Clockwork\Support\Slim\ClockworkMiddleware;
 use JR\Tracker\Config;
 use JR\Tracker\Enum\AppEnvironmentEnum;
+use JR\Tracker\Middleware\SessionStartMiddleware;
 use JR\Tracker\Middleware\ValidationExceptionMiddleware;
 use JR\Tracker\Middleware\VerificationExceptionMiddleware;
 use Slim\App;
@@ -16,6 +17,10 @@ return function (App $app) {
 
   if ($config->get('csrf_enabled')) {
     $app->add('csrf');
+    // Slim spousti naposledy pridany middleware jako prvni, takze tohle
+    // zajisti, ze session bezi jeste pred CSRF Guardem (ten ji potrebuje
+    // jako storage).
+    $app->add(SessionStartMiddleware::class);
   }
 
   $app->add(VerificationExceptionMiddleware::class);


### PR DESCRIPTION
## Summary
- CSRF Guard (`persistentTokenMode: true`) potřebuje session jako storage, ale nic ji nespouštělo - RuntimeException "Invalid CSRF storage"
- Přidán `SessionStartMiddleware`, zapojený hned po `'csrf'` v `middleware.php` (Slim spouští naposledy přidaný middleware jako první, takže tohle zajistí správné pořadí)

## Test plan
- [x] `php -l` bez chyby
- [x] `phpstan analyse app` čistý
- [ ] Po nasazení ověřit, že appka s `CSRF_ENABLED=true` odpovídá bez 500 chyby