### PR TITLE
Only build-and-push on develop pushes or version tags

### DIFF
--- a/.github/workflows/php-api-ci.yml
+++ b/.github/workflows/php-api-ci.yml
@@ -128,7 +128,11 @@ jobs:
   build-and-push:
     name: Build & Push Image
     needs: test
-    if: github.event_name == 'push'
+    # jen push do develop (dev deploy) nebo vytvoreni verzoveho tagu (prod
+    # deploy) - obycejny push/merge do main bez tagu nema nic spoustet
+    if: |
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Merge do main bez tagu omylem taky spouštěl build-and-push (a tím zbytečně redeploy do dev). Teď spouští jen push do develop nebo vytvoření v* tagu.