### PR TITLE
Transliterate APP_NAME before using it in cookie names

### DIFF
--- a/src/api/configs/app.php
+++ b/src/api/configs/app.php
@@ -13,7 +13,16 @@ $boolean = function (mixed $value) {
   return false;
 };
 $appEnv = $_ENV['APP_ENV'] ?? AppEnvironmentEnum::Production->value;
-$appSnakeName = strtolower(str_replace(' ', '_', $_ENV['APP_NAME']));
+
+// Cookie/session names must stay pure ASCII (RFC 6265 token) - APP_NAME can contain
+// diacritics (e.g. "Spotřeba energie"), which would otherwise land raw in the cookie
+// name and get mangled differently across HTTP/2, proxies and PHP, breaking sessions.
+$appNameAscii = strtr(mb_strtolower($_ENV['APP_NAME'], 'UTF-8'), [
+  'á' => 'a', 'č' => 'c', 'ď' => 'd', 'é' => 'e', 'ě' => 'e', 'í' => 'i',
+  'ň' => 'n', 'ó' => 'o', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ú' => 'u',
+  'ů' => 'u', 'ý' => 'y', 'ž' => 'z',
+]);
+$appSnakeName = trim((string) preg_replace('/[^a-z0-9]+/', '_', $appNameAscii), '_');
 
 
 return [


### PR DESCRIPTION
## Summary
- Fixes a 403 on login on the deployed dev environment, traced to a corrupted session cookie name visible in DevTools as `spotÅ™eba_energie_session` (mojibake)
- Cause: `APP_NAME` (`"Spotřeba energie"`, with diacritics) was used raw to build session/refreshToken cookie names via `$appSnakeName`, producing a cookie name containing a literal UTF-8 `ř`. Cookie names must be pure ASCII per RFC 6265 - undefined behavior across proxies/HTTP versions otherwise
- `app_name` (used as-is in emails, e.g. `PasswordResetEmail.php`, `SignUpEmail.php`) is untouched - only the derived, ASCII-only `$appSnakeName` used for cookie names changes

## Test plan
- [x] `php -l` and PHPStan pass locally
- [ ] After merge/deploy, confirm login succeeds against the dev environment and the session cookie name is plain ASCII in DevTools