### PR TITLE
Expose CSRF token via response headers for the SPA frontend

### DIFF
--- a/src/api/app/Middleware/ExposeCsrfTokenMiddleware.php
+++ b/src/api/app/Middleware/ExposeCsrfTokenMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JR\Tracker\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+// Appka je SPA na samostatné doméně/cestě, ne server-rendered appka s Twig
+// šablonami - Guard sice na každý request sám připojí aktuální csrf_name/
+// csrf_value jako atributy requestu, ale nikam v HTML je vložit nejde.
+// Musí se dostat k JS klientovi prostřednictvím response hlaviček - klient
+// si je uloží do paměti (ne do cookie, tu JS záměrně nesmí číst) a pošle
+// zpátky na mutujících requestech.
+class ExposeCsrfTokenMiddleware implements MiddlewareInterface
+{
+  public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+  {
+    $response = $handler->handle($request);
+
+    $csrfName = $request->getAttribute('csrf_name');
+    $csrfValue = $request->getAttribute('csrf_value');
+
+    if (!is_string($csrfName) || !is_string($csrfValue)) {
+      return $response;
+    }
+
+    return $response
+      ->withHeader('csrf_name', $csrfName)
+      ->withHeader('csrf_value', $csrfValue);
+  }
+}

--- a/src/api/configs/allowed_origins.php
+++ b/src/api/configs/allowed_origins.php
@@ -16,7 +16,8 @@ if ($isDevelopment) {
   }
 
   header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS");
-  header("Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization");
+  header("Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization, csrf_name, csrf_value");
+  header("Access-Control-Expose-Headers: csrf_name, csrf_value");
   header("Access-Control-Allow-Credentials: true");
 
   if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {

--- a/src/api/configs/middleware.php
+++ b/src/api/configs/middleware.php
@@ -6,6 +6,7 @@ use Clockwork\Clockwork;
 use Clockwork\Support\Slim\ClockworkMiddleware;
 use JR\Tracker\Config;
 use JR\Tracker\Enum\AppEnvironmentEnum;
+use JR\Tracker\Middleware\ExposeCsrfTokenMiddleware;
 use JR\Tracker\Middleware\SessionStartMiddleware;
 use JR\Tracker\Middleware\ValidationExceptionMiddleware;
 use JR\Tracker\Middleware\VerificationExceptionMiddleware;
@@ -16,10 +17,13 @@ return function (App $app) {
   $config = $container->get(Config::class);
 
   if ($config->get('csrf_enabled')) {
+    // Slim spousti naposledy pridany middleware jako prvni. Poradi provedeni
+    // (od outer po inner): SessionStart -> csrf Guard -> ExposeCsrfToken ->
+    // routa. Guard musi bezet pred ExposeCsrfTokenMiddleware (potrebuje jeho
+    // atributy csrf_name/csrf_value), a az po SessionStartMiddleware (ten mu
+    // dodava session jako storage).
+    $app->add(ExposeCsrfTokenMiddleware::class);
     $app->add('csrf');
-    // Slim spousti naposledy pridany middleware jako prvni, takze tohle
-    // zajisti, ze session bezi jeste pred CSRF Guardem (ten ji potrebuje
-    // jako storage).
     $app->add(SessionStartMiddleware::class);
   }
 


### PR DESCRIPTION
## Summary
- Fixes 403 on login (and every other mutating request) on the dev environment - `CSRF_ENABLED` is `true` in k8s dev but the frontend never sent a CSRF token, so Slim-Csrf's Guard rejected every POST/PUT/PATCH/DELETE outright
- Companion PR on `consumption-web` (#163) makes the frontend actually use this

## Why not the pattern from the reference project
The CSRF setup here was originally modeled on `expennies` (a learning project), which is server-rendered (Twig) - it injects `csrf_name`/`csrf_value` as hidden form fields via a Twig global. That only works when the backend renders the HTML itself. This API only returns JSON to a separately hosted SPA, so there's no shared page to inject a hidden field into - the token has to reach the JS client some other way.

## Approach
`ExposeCsrfTokenMiddleware` copies the `csrf_name`/`csrf_value` request attributes Guard already sets on every request (thanks to `persistentTokenMode`) onto the response headers of every response. The frontend picks them up from any API response and echoes them back as headers on mutating requests.

Deliberately **not** a cookie (double-submit pattern) - want to keep the token out of anything JS-readable by default; a plain response header round-tripped through app memory avoids introducing a non-`HttpOnly` cookie.

Also widened dev CORS (`allowed_origins.php`) to allow/expose these headers - needed when frontend and API run on different ports (local dev); already same-origin in k8s so this is a no-op there.

## Test plan
- [x] `php -l`, PHPStan, and `composer test` (32 tests) pass locally
- [ ] After merge, deploy alongside consumption-web#163 and confirm login succeeds on the dev environment