### PR TITLE
Fix CSRF token never reaching response headers

### DIFF
--- a/src/api/app/Middleware/ExposeCsrfTokenMiddleware.php
+++ b/src/api/app/Middleware/ExposeCsrfTokenMiddleware.php
@@ -4,27 +4,47 @@ declare(strict_types=1);
 
 namespace JR\Tracker\Middleware;
 
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Csrf\Guard;
 
 // Appka je SPA na samostatné doméně/cestě, ne server-rendered appka s Twig
 // šablonami - Guard sice na každý request sám připojí aktuální csrf_name/
 // csrf_value jako atributy requestu, ale nikam v HTML je vložit nejde.
-// Musí se dostat k JS klientovi prostřednictvím response hlaviček - klient
-// si je uloží do paměti (ne do cookie, tu JS záměrně nesmí číst) a pošle
-// zpátky na mutujících requestech.
+// Musí se dostat k JS klientovi prostřednictvím response hlaviček.
+//
+// Záměrně nečte $request->getAttribute() - tyhle atributy nastavuje Guard
+// jen na $request, který sám předá dál přes $handler->handle(). Při
+// neúspěšné CSRF validaci Guard $handler->handle() vůbec nezavolá
+// (handleFailure() vrací rovnou svou vlastní odpověď) a při výjimce
+// hlouběji v aplikaci (např. neplatná session) atributy nepřežijí -
+// výjimka postup přes middleware "přeskočí". Guard si ale svůj aktuální
+// token drží i jako vlastní vnitřní stav (nastavuje se jako vedlejší
+// efekt při generateToken()/loadLastKeyPair(), v obou případech), takže
+// se čte přímo z instance Guardu, ne z requestu - a middleware musí být
+// nejvíc vnější vrstva (obaluje i middlewary, co převádí výjimky na
+// odpovědi), aby zachytil úplně každou odpověď bez ohledu na to, jak
+// vznikla.
 class ExposeCsrfTokenMiddleware implements MiddlewareInterface
 {
+  public function __construct(
+    private readonly ContainerInterface $container
+  ) {
+  }
+
   public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
   {
     $response = $handler->handle($request);
 
-    $csrfName = $request->getAttribute('csrf_name');
-    $csrfValue = $request->getAttribute('csrf_value');
+    /** @var Guard $guard */
+    $guard = $this->container->get('csrf');
+    $csrfName = $guard->getTokenName();
+    $csrfValue = $guard->getTokenValue();
 
-    if (!is_string($csrfName) || !is_string($csrfValue)) {
+    if ($csrfName === null || $csrfValue === null) {
       return $response;
     }
 

--- a/src/api/configs/middleware.php
+++ b/src/api/configs/middleware.php
@@ -17,13 +17,10 @@ return function (App $app) {
   $config = $container->get(Config::class);
 
   if ($config->get('csrf_enabled')) {
-    // Slim spousti naposledy pridany middleware jako prvni. Poradi provedeni
-    // (od outer po inner): SessionStart -> csrf Guard -> ExposeCsrfToken ->
-    // routa. Guard musi bezet pred ExposeCsrfTokenMiddleware (potrebuje jeho
-    // atributy csrf_name/csrf_value), a az po SessionStartMiddleware (ten mu
-    // dodava session jako storage).
-    $app->add(ExposeCsrfTokenMiddleware::class);
     $app->add('csrf');
+    // Slim spousti naposledy pridany middleware jako prvni, takze tohle
+    // zajisti, ze session bezi jeste pred CSRF Guardem (ten ji potrebuje
+    // jako storage).
     $app->add(SessionStartMiddleware::class);
   }
 
@@ -35,6 +32,16 @@ return function (App $app) {
   }
 
   $app->addBodyParsingMiddleware();
+
+  if ($config->get('csrf_enabled')) {
+    // Musi byt nejvic vnejsi vrstva (pridano tesne pred addErrorMiddleware),
+    // aby obalilo i Validation/VerificationExceptionMiddleware - ty vyjimky
+    // hlouběji v appce prevadi na Response, coz "prelétne" kolem cehokoliv
+    // vnitrniho. ExposeCsrfTokenMiddleware proto cte token primo z Guard
+    // instance (viz komentar v tom souboru), ne z $request atributu.
+    $app->add(ExposeCsrfTokenMiddleware::class);
+  }
+
   $app->addErrorMiddleware(
     (bool) $config->get('display_error_details'),
     (bool) $config->get('log_errors'),


### PR DESCRIPTION
## Summary
Follow-up to #127. Confirmed via `curl -kv` directly against the deployed dev environment that `ExposeCsrfTokenMiddleware` never actually produced any `csrf_name`/`csrf_value` response header, on any response - success or failure.

## Root cause
The middleware was positioned inward of the CSRF Guard and read the token from `$request` attributes:
- `Guard::handleFailure()` returns its own response directly without ever calling `$handler->handle()` - so on any CSRF-rejected request (e.g. login), the middleware never ran at all.
- On requests where deeper code throws (e.g. the `"noCookie"` 401 from `refreshToken`), the exception unwinds straight past the middleware to the outer `Validation`/`VerificationExceptionMiddleware` that catches it - request-attribute state doesn't survive that, only the final returned `Response` does.

## Fix
- Read the token from the `Guard` instance itself (`getTokenName()`/`getTokenValue()`, populated as a side effect of `generateToken()`/`loadLastKeyPair()` regardless of how the request ends) instead of request attributes
- Move the middleware to be the outermost layer (added right before `addErrorMiddleware`) so it wraps every possible response - normal, CSRF-rejected, or exception-turned-into-response alike

## Test plan
- [x] `php -l`, PHPStan, and `composer test` (32 tests) pass locally
- [ ] After merge/deploy, `curl -kv https://spotreba-energie.local/api/web/auth/refreshToken` should show `csrf_name`/`csrf_value` response headers; login should succeed from the frontend